### PR TITLE
Add resolveAndGetContext and resolveAndGetMappedValues methods to Parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5494,9 +5494,9 @@
       }
     },
     "velocityjs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/velocityjs/-/velocityjs-2.0.1.tgz",
-      "integrity": "sha1-B4xz0ipT8IXPOlKlaoJxyCCsI90="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/velocityjs/-/velocityjs-2.0.3.tgz",
+      "integrity": "sha512-sUkygY7HwvbKZvS3naiI7t2o4RTqui6efSwTXLb03igdvPKm3SwCpnqA2kU4/jLD2f0eHB9xPoiza9XAkpuU+g=="
     },
     "verror": {
       "version": "1.10.0",


### PR DESCRIPTION
We've been looking for a way to get the context and stash after processing vtl files so we can write unit tests for response.vtl templates that are not used for returning (HydrateCarers, etc)

This adds in `resolveAndGetContext` and `resolveAndGetMappedValues` that allow us to get the full context and an array of values updated by set:

Instead of or along with calling `const rendered = parser.resolve(context)` we can now also call

```
const contextObj = parser.resolveAndGetContext(context)
```

The context gets updated through js but was being cloned before being passed through to velocityjs, so simply returning the context after rendering will return the updated context.
 
```
const mappedValues = parser.resolveAndGetMappedValues(context)
```

Velocityjs compiler has a valueMapper property that gets all the values updated using `#set()` passed through to so this can be used to get all the values set in a template and test if they are what we are expecting.